### PR TITLE
[FEAT/5week] JPA 활용(JPQL 방식으로 쿼리 리팩토링)

### DIFF
--- a/src/main/java/com/example/umc9th/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/umc9th/domain/member/repository/MemberRepository.java
@@ -1,0 +1,21 @@
+package com.example.umc9th.domain.member.repository;
+
+import com.example.umc9th.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    /*
+     * 멤버 id = 1 인 멤버 정보 조회
+     * 실행되는 JPQL: SELECT m FROM Member m WHERE m.id = ?1
+     * Optional<Member> findById(Long id);  // JpaRepository가 기본 제공
+     */
+
+    // 쿼리 어노테이션 사용
+    @Query("select m from Member m where m.id = :memberId")
+    Optional<Member> findMemberById(@Param("memberId") Long memberId);
+}

--- a/src/main/java/com/example/umc9th/domain/mission/repository/MemberMissionRepository.java
+++ b/src/main/java/com/example/umc9th/domain/mission/repository/MemberMissionRepository.java
@@ -1,0 +1,22 @@
+package com.example.umc9th.domain.mission.repository;
+
+import com.example.umc9th.domain.mission.entity.MemberMission;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface MemberMissionRepository extends JpaRepository<MemberMission, Long> {
+
+    // 내가 진행중, 진행 완료한 미션 목록
+    @Query("select mm from MemberMission mm " +
+            "join fetch mm.mission m " +
+            "where mm.member.id = :memberId " +
+            "and mm.id < :cursor " +
+            "order by case when mm.status = 'CHALLENGING' then 1 else 2 end, mm.id desc")
+    List<MemberMission> findMemberMissions(
+            @Param("memberId") Long memberId,
+            @Param("cursor") Long cursor
+    );
+}

--- a/src/main/java/com/example/umc9th/domain/mission/repository/MissionRepository.java
+++ b/src/main/java/com/example/umc9th/domain/mission/repository/MissionRepository.java
@@ -1,0 +1,28 @@
+package com.example.umc9th.domain.mission.repository;
+
+import com.example.umc9th.domain.mission.entity.Mission;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface MissionRepository extends JpaRepository<Mission, Long> {
+
+    // 현재 선택된 지역에서 도전 가능한 미션 목록
+    @Query("select m from Mission m " +
+            "join fetch m.store s " +
+            "where s.region.id = :regionId " +
+            "and m.id < :cursor " +
+            "and m.id not in (" +
+            "    select mm.mission.id " +
+            "    from MemberMission mm " +
+            "    where mm.member.id = :memberId" +
+            ") " +
+            "order by m.id desc")
+    List<Mission> findAvailableMissions(
+            @Param("regionId") Long regionId,
+            @Param("memberId") Long memberId,
+            @Param("cursor") Long cursor
+    );
+}

--- a/src/main/java/com/example/umc9th/domain/mission/service/MissionService.java
+++ b/src/main/java/com/example/umc9th/domain/mission/service/MissionService.java
@@ -1,0 +1,53 @@
+package com.example.umc9th.domain.mission.service;
+
+import com.example.umc9th.domain.mission.entity.MemberMission;
+import com.example.umc9th.domain.mission.entity.Mission;
+import com.example.umc9th.domain.mission.repository.MemberMissionRepository;
+import com.example.umc9th.domain.mission.repository.MissionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MissionService {
+
+    private final MemberMissionRepository memberMissionRepository;
+    private final MissionRepository missionRepository;
+    /**
+     * 커서 기반 미션 조회
+     * @param memberId 회원 ID
+     * @param cursor 커서 값 (null이면 첫 페이지)
+     */
+    public List<MemberMission> getMemberMissions(Long memberId, Long cursor) {
+        // cursor가 null이면 Long.MAX_VALUE 사용 (첫 페이지를 의미)
+        Long cursorValue = (cursor != null) ? cursor : Long.MAX_VALUE;
+
+        return memberMissionRepository
+                .findMemberMissions(memberId, cursorValue)
+                .stream()
+                .limit(10)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 도전 가능한 미션 목록 조회 (커서 기반 페이징)
+     *
+     * @param regionId 지역 ID
+     * @param memberId 회원 ID (이미 도전중인 미션 제외용)
+     * @param cursor 커서 값 (null이면 첫 페이지)
+     * @return 미션 목록 (최대 10개)
+     */
+    public List<Mission> getAvailableMissions(Long regionId, Long memberId, Long cursor) {
+        // cursor가 null이면 Long.MAX_VALUE 사용 (첫 페이지)
+        Long cursorValue = (cursor != null) ? cursor : Long.MAX_VALUE;
+
+        return missionRepository
+                .findAvailableMissions(regionId, memberId, cursorValue)
+                .stream()
+                .limit(10)  // 최대 10개
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/umc9th/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/umc9th/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,8 @@
+package com.example.umc9th.domain.review.repository;
+
+import com.example.umc9th.domain.review.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+    // save() 메서드는 JpaRepository가 자동 제공
+}

--- a/src/main/java/com/example/umc9th/domain/review/service/ReviewService.java
+++ b/src/main/java/com/example/umc9th/domain/review/service/ReviewService.java
@@ -1,0 +1,33 @@
+package com.example.umc9th.domain.review.service;
+
+import com.example.umc9th.domain.member.entity.Member;
+import com.example.umc9th.domain.review.entity.Review;
+import com.example.umc9th.domain.review.repository.ReviewRepository;
+import com.example.umc9th.domain.store.entity.Store;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReviewService {
+
+    private final ReviewRepository reviewRepository;
+
+    // 리뷰 작성 쿼리
+    @Transactional
+    public Review createReview(Member member, Store store, String title, String content, Float rate) {
+        Review review = Review.builder()
+                .member(member)
+                .store(store)
+                .title(title)      // 제목 추가 (엔티티에 있음)
+                .body(content)     // SQL의 content -> body
+                .score(rate)       // SQL의 rate -> score
+                .build();
+
+        // JPA의 save() 메서드가 자동으로 INSERT 쿼리 생성
+        // created_at, updated_at은 자동으로 설정됨
+        return reviewRepository.save(review);
+    }
+}


### PR DESCRIPTION
## 🎋 작업중인 브랜치
#4 , feat/5week-jpql

## ⚡️ 작업동기
### 1. JPA와 영속성 컨텍스트 (Persistence Context)의 핵심 이해

JPA는 객체와 RDB 간의 패러다임 불일치를 해소하는 ORM 기술이며, 그 중심에는 **영속성 컨텍스트**가 있습니다.

* **영속성 컨텍스트**: 엔티티 객체를 영구적(persistent)으로 관리하고 변경을 추적하는 **메모리상의 논리적 공간**입니다. 이는 DB 접근 횟수를 줄이는 **1차 캐시** 역할을 합니다.
* **영속 상태의 주요 이점**: 엔티티가 관리 상태(Managed)가 되면 다음과 같은 장점을 얻습니다.
    1.  **1차 캐시**: 동일 트랜잭션 내 중복 조회 시 DB 접근 없이 캐시 데이터를 즉시 반환합니다.
    2.  **변경 감지 (Dirty Checking)**: 엔티티 수정 시 트랜잭션 커밋 시점에 JPA가 자동으로 감지하여 **`UPDATE` 쿼리**를 생성하고 반영합니다.
    3.  **지연 로딩 (Lazy Loading)**: 연관된 엔티티를 실제로 **사용하는 시점**에만 조회합니다. (N+1 문제 방지를 위해 EAGER 대신 권장)

---

### 2. Spring Data JPA를 통한 데이터 접근 및 쿼리 전략

Spring Data JPA는 `Repository` 인터페이스를 사용하여 DB 접근을 간소화할 수 있습니다. 이번 미션에서는 **`@Query` 어노테이션**으로 JPQL을 직접 작성하는 방식을 사용했습니다.

* **기본 CRUD 및 `save()`**: `JpaRepository` 상속으로 기본적인 CRUD가 제공됩니다. `reviewRepository.save(review)` 호출은 엔티티를 영속화하고, 트랜잭션 커밋 시점에 **`INSERT` 쿼리**를 자동 실행합니다.
* **`@Query`와 JPQL**: 복잡한 조회 조건이나 커스터마이징을 위해 `@Query`를 사용하며, **테이블이 아닌 엔티티 객체**를 대상으로 쿼리하는 **JPQL**을 작성했습니다.
    * **예시**: `findMemberById` 메서드는 `@Query("select m from Member m where m.id = :memberId")`를 통해 특정 ID의 `Member` 엔티티를 조회합니다.

---

### 3. 성능 최적화 전략: N+1 문제와 커서 페이징

효율적인 데이터 조회와 대용량 처리를 위해 다음과 같은 최적화 전략을 적용했습니다.

#### ① N+1 문제 해결을 위한 `join fetch` (페치 조인)

* **문제**: **즉시 로딩 (EAGER)** 사용 시 발생하는 **N+1 문제** (1개 메인 쿼리 후 N개 추가 쿼리)를 방지하기 위해 **페치 조인**을 사용했습니다.
* **적용**: `findMemberMissions`와 `findAvailableMissions` 쿼리에서 `join fetch`를 사용하여 연관된 엔티티 (`mm.mission`, `m.store`)를 **하나의 쿼리로** 함께 조회함으로써, N+1 문제를 근본적으로 해결하고 성능을 최적화했습니다.

#### ② 커서 기반 페이징

* **전략**: **오프셋(Offset) 기반 페이징의 성능 저하**를 피하기 위해 **커서 기반 페이징**을 적용했습니다.
* **구현**: `WHERE mm.id < :cursor`와 같이 이전에 조회된 **마지막 레코드의 ID**를 기준으로 다음 페이지를 조회하도록 구현했습니다.
* **서비스 로직**: `MissionService`에서 `cursor`가 `null`인 경우 `Long.MAX_VALUE`를 사용하여 첫 페이지부터 최신 데이터를 조회하도록 처리했습니다.

#### ③ 비즈니스 로직 구현

* **정렬 조건**: `findMemberMissions`에서 `order by case when mm.status = 'CHALLENGING' then 1 else 2 end`를 사용하여 **진행 중인 미션**을 완료된 미션보다 **우선적으로 정렬**하는 로직을 JPQL 내에서 구현했습니다.
* **필터링**: `findAvailableMissions`에서 **서브 쿼리**를 이용해 `and m.id not in (...)` 조건을 적용하여, **이미 도전 중인 미션은 목록에서 제외**하는 복잡한 필터링을 구현했습니다. 추후 QueryDSL과 같이 쿼리 빌더 라이브러리를 사용해서 리팩토링을 진행할수도 있겠습니다.


## Check List

- [ ] **Reviewers** 등록을 하였나요?
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!